### PR TITLE
feat: pre-commitのdeptryとmypyを再有効化

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,10 +34,14 @@ repos:
     rev: v1.5.0
     hooks:
       - id: detect-secrets
-  # - repo: https://github.com/fpgmaas/deptry
-  #   rev: 0.23.1
-  #   hooks:
-  #     - id: deptry
+  - repo: https://github.com/fpgmaas/deptry
+    rev: 0.23.1
+    hooks:
+      - id: deptry
+        language: python
+        entry: deptry
+        args: [--config, pyproject.toml, "src"]
+        types: [python]
   - repo: local
     hooks:
       - id: safety
@@ -48,11 +52,12 @@ repos:
         additional_dependencies: ["safety", "uv"]
         files: ^(pyproject\\.toml|uv\\.lock)$
         pass_filenames: false
-  # - repo: https://github.com/pre-commit/mirrors-mypy
-  #   rev: v1.10.1
-  #   hooks:
-  #     - id: mypy
-  #       args: [--config-file=pyproject.toml, --exclude, "uv-docker-example-main/"]
-  #       additional_dependencies:
-  #         - types-click
-  #         - typer
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.10.1
+    hooks:
+      - id: mypy
+        files: ^src/
+        args: [--config-file=pyproject.toml]
+        additional_dependencies:
+          - types-click
+          - typer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ testpaths = ["tests"]
 exclude_dirs = ["tests"]
 
 [tool.mypy]
-exclude = "uv-docker-example-main"
 
 [tool.ruff]
 line-length = 88
@@ -42,3 +41,8 @@ ignore = []
 [tool.ruff.format]
 quote-style = "double"
 indent-style = "space"
+
+[tool.deptry]
+exclude = ["uv-docker-example-main", "tests"]
+ignore_notebooks = true
+ignore = ["DEP002"]


### PR DESCRIPTION
pre-commitフックのdeptryとmypyを再度有効化し、関連する問題を修正しました。

deptryは設定ファイルと対象ディレクトリを引数で指定することで、\`Missing argument\`エラーを解決しました。
mypyはpre-commitのfilesディレクティブでチェック対象を\`src/\`ディレクトリに限定することで、プロジェクト外のファイルに対する型エラーを解消しました。

これにより、CI/CDパイプラインにおけるコード品質チェックが正常に機能するようになります。

Closes #22