### PR TITLE
feat: versionサブコマンドと--versionオプションを追加

### DIFF
--- a/src/my_app/cli.py
+++ b/src/my_app/cli.py
@@ -1,6 +1,17 @@
+import importlib.metadata
+
 import typer
 
+__version__ = importlib.metadata.version("my-app")
+
 app = typer.Typer()
+
+
+def version_callback(value: bool) -> None:
+    """バージョン情報を表示して終了する"""
+    if value:
+        print(f"my-app version: {__version__}")
+        raise typer.Exit()
 
 
 @app.command()
@@ -9,8 +20,23 @@ def hello(name: str) -> None:
     print(f"hello {name}")
 
 
+@app.command()
+def version() -> None:
+    """バージョン情報を表示する"""
+    print(f"my-app version: {__version__}")
+
+
 @app.callback()
-def main() -> None:
+def main(
+    version: bool | None = typer.Option(
+        None,
+        "--version",
+        "-v",
+        help="バージョン情報を表示する",
+        callback=version_callback,
+        is_eager=True,
+    ),
+) -> None:
     """my-app CLI アプリケーション"""
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,10 +2,13 @@
 CLIアプリケーションのテスト
 """
 
+import importlib.metadata
+
 from my_app.cli import app
 from typer.testing import CliRunner
 
 runner = CliRunner()
+__version__ = importlib.metadata.version("my-app")
 
 
 def test_hello_command():
@@ -43,3 +46,24 @@ def test_hello_without_argument():
     assert result.exit_code != 0
     # Typerのエラーメッセージは通常stderrに出力される
     assert "Missing argument" in result.stderr or result.exit_code == 2
+
+
+def test_version_subcommand():
+    """versionサブコマンドが正しく動作することをテスト"""
+    result = runner.invoke(app, ["version"])
+    assert result.exit_code == 0
+    assert f"my-app version: {__version__}" in result.stdout
+
+
+def test_version_option():
+    """--versionオプションが正しく動作することをテスト"""
+    result = runner.invoke(app, ["--version"])
+    assert result.exit_code == 0
+    assert f"my-app version: {__version__}" in result.stdout
+
+
+def test_version_option_short():
+    """-vオプションが正しく動作することをテスト"""
+    result = runner.invoke(app, ["-v"])
+    assert result.exit_code == 0
+    assert f"my-app version: {__version__}" in result.stdout


### PR DESCRIPTION

\`my-app\` CLIに、アプリケーションのバージョン情報を表示する機能を追加しました。

- \`importlib.metadata\` を利用して \`pyproject.toml\` からバージョンを動的に取得します。
- \`--version\` および \`-v\` オプションでバージョン情報を表示して終了する機能を追加しました。
- \`version\` サブコマンドでも同様にバージョン情報を表示できます。
- 上記の機能に対するテストケースを追加しました。

Closes #28
